### PR TITLE
Added support for both 'href' and the deprecated value 'xlink:href'

### DIFF
--- a/scripts/generateHTML.js
+++ b/scripts/generateHTML.js
@@ -95,7 +95,8 @@ function generateSprite(options, icons, Document){
         const svg = Document.createElement("svg");
 
         const use = Document.createElement("use");
-        use.setAttribute("xlink:href", options.xLinkHref + "#" + item.replace(".svg", ""))
+        use.setAttribute("xlink:href", options.xLinkHref + "#" + item.replace(".svg", ""));
+        use.setAttribute("href", options.xLinkHref + "#" + item.replace(".svg", ""));
 
         svg.appendChild(titleTag);
         svg.appendChild(descTag);


### PR DESCRIPTION
Added support for both 'href' attribute since 'xlink:href' is deprecated since SVG 2 (https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/xlink:href) according to W3C guidelines: _"For backwards compatibility, elements with an ‘href’ attribute also recognize an ‘href’ attribute in the XLink namespace"(https://svgwg.org/svg2-draft/linking.html#XLinkRefAttrs)_.