### PR TITLE
Make circle radius the same as other circle icons

### DIFF
--- a/icons/circle.svg
+++ b/icons/circle.svg
@@ -1,4 +1,4 @@
 <svg role="img" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" aria-labelledby="circleIconTitle">
     <title id="circleIconTitle">Circle</title>    
-    <circle cx="12" cy="12" r="8"/>
+    <circle cx="12" cy="12" r="10"/>
 </svg>


### PR DESCRIPTION
I noticed that the standalone circle icon had a different radius than the other circle icons (e.g. `circle-ok`). It made it awkward when trying to use them together to toggle states, etc. This PR makes the radii match.